### PR TITLE
feat: 🎸 use scheduler.yeild and requestAnimationFrame

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function nextFrameYield() {
 function forceYield(frame?: number) {
   const context = getGlobalContext() as Window;
 
-  if (context.scheduler?.yield) {
+  if (typeof context.scheduler?.yield === 'function') {
     return context.scheduler.yield();
   }
 


### PR DESCRIPTION
The scheduler.yield is used by default if env supported it. The nextFrameYield method  use requestAnimationFrame is env supported it.